### PR TITLE
IT-1983 | Elastic APM 7.x support for Laravel 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The following environment variables are supported in the default configuration:
 |APM_SECRETTOKEN    | Secret token, if required. |
 |APM_APIVERSION     | APM API version, defaults to `v1` (only v1 is supported at this time). |
 |APM_USEROUTEURI    | `true` or `false` defaults to `false`. The default behavior is to record the URL as sent in the request. This can result in excessive unique entries in APM. Set to `true` to have the agent use the route URL instead. |
+|APM_NORMALIZEURI   | `true` or `false` defaults to `false`. If enabled, removes variable parts from URI when generating transaction name (e.g. `GET /foo/bar/123` is reported as `GET /foo/bar/N`). **`APM_USEROUTEURI` needs to be enabled**. |
 |APM_QUERYLOG       | `true` or `false` defaults to 'true'. Set to `false` to completely disable query logging, or to `auto` if you would like to use the threshold feature. |
 |APM_THRESHOLD      | Query threshold in milliseconds, defaults to `200`. If a query takes longer then 200ms, we enable the query log. Make sure you set `APM_QUERYLOG=auto`. |
 |APM_BACKTRACEDEPTH | Defaults to `25`. Depth of backtrace in query span. |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ composer require bethinkpl/elastic-apm-laravel
 ## Additional features
 
 * `X-Requested-By` HTTP request header value is set as `labels.requested_by` APM transaction field (`end-user-ajax` value is used when `X-Requested-With: XMLHttpRequest` is set)
+* tracking of HTTP requests performed using GuzzleHttp library. Simply add the following middleware to your Guzzle client:
+
+```php
+<?php
+
+use PhilKra\ElasticApmLaravel\Providers\ElasticApmServiceProvider;
+use GuzzleHttp\HandlerStack;
+
+$handler = HandlerStack::create();
+$handler->push(ElasticApmServiceProvider::getGuzzleMiddleware());
+
+// create your client with 'handler' option passed
+```
 
 ## Middleware
 ### Laravel

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The following environment variables are supported in the default configuration:
 |APM_THRESHOLD      | Query threshold in milliseconds, defaults to `200`. If a query takes longer then 200ms, we enable the query log. Make sure you set `APM_QUERYLOG=auto`. |
 |APM_BACKTRACEDEPTH | Defaults to `25`. Depth of backtrace in query span. |
 |APM_RENDERSOURCE   | Defaults to `true`. Include source code in query span. |
+|APM_HTTPLOG        | Defaults to `true`. Will record HTTP requests performed via GuzzleHttp. |
 
 You may also publish the `elastic-apm.php` configuration file to change additional settings:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Laravel package of the https://github.com/philkra/elastic-apm-php-agent library, automatically handling transactions and errors/exceptions. If using `Illuminate\Support\Facades\Auth` the user Id added to the context.
 Tested with Laravel `5.7.*` and the philkra/elastic-apm-php-agent version `7.x`.
 
-## Install
+## [Install](https://packagist.org/packages/bethinkpl/elastic-apm-laravel)
 ```
 composer require bethinkpl/elastic-apm-laravel
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # PHP Elastic APM for Laravel & Lumen
 
 Laravel package of the https://github.com/philkra/elastic-apm-php-agent library, automatically handling transactions and errors/exceptions. If using `Illuminate\Support\Facades\Auth` the user Id added to the context.
-Tested with Laravel `5.6.*` and the philkra/elastic-apm-php-agent version `7.x`.
+Tested with Laravel `5.7.*` and the philkra/elastic-apm-php-agent version `7.x`.
 
 ## Install
 ```
-composer require philkra/elastic-apm-laravel
+composer require bethinkpl/elastic-apm-laravel
 ```
+
+## Additional features
+
+* `X-Requested-By` HTTP request header value is set as `labels.requested_by` APM transaction field (`end-user-ajax` value is used when `X-Requested-With: XMLHttpRequest` is set)
 
 ## Middleware
 ### Laravel

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
    "name":"bethinkpl/elastic-apm-laravel",
-   "keywords":[  
+   "keywords":[
       "laravel",
       "elastic",
       "APM",
@@ -10,48 +10,50 @@
    ],
    "description":"A package to integrate Elastic APM 7.x into Laravel",
    "license":"MIT",
-   "require":{  
+   "require":{
       "php":">= 7.2",
       "illuminate/database":"^6.0",
       "illuminate/http":"^6.0",
       "illuminate/routing":"^6.0",
       "illuminate/support":"^6.0",
       "philkra/elastic-apm-php-agent":"7.0.0-rc3",
-      "ramsey/uuid":"^3.0"
+      "ramsey/uuid":"^3.0",
+      "psr/http-message":"^1.0",
+      "guzzlehttp/guzzle":"~6.0"
    },
-   "require-dev":{  
+   "require-dev":{
       "phpunit/phpunit":"6.*"
    },
-   "autoload":{  
-      "psr-4":{  
+   "autoload":{
+      "psr-4":{
          "PhilKra\\ElasticApmLaravel\\":"src/"
       }
    },
-   "autoload-dev":{  
-      "psr-4":{  
+   "autoload-dev":{
+      "psr-4":{
          "PhilKra\\Tests\\":"tests/"
       }
    },
-   "extra":{  
-      "laravel":{  
-         "providers":[  
+   "extra":{
+      "laravel":{
+         "providers":[
             "PhilKra\\ElasticApmLaravel\\Providers\\ElasticApmServiceProvider"
          ],
-         "aliases":{  
+         "aliases":{
             "ElasticApm":"PhilKra\\ElasticApmLaravel\\Facades\\ElasticApm"
          }
       }
    },
-   "config":{  
+   "config":{
       "optimize-autoloader":true
    },
-   "authors":[  
-      {  
+   "authors":[
+      {
          "name":"Philip Krauss",
          "email":"philip@philipkrauss.at",
          "homepage":"https://github.com/philkra/elastic-apm-laravel"
       },
-      {  
+      {
          "name":"George Boot",
          "email":"george@entryninja.com"
       }

--- a/config/elastic-apm.php
+++ b/config/elastic-apm.php
@@ -61,5 +61,10 @@ return [
             // If a query takes longer then 200ms, we enable the query log. Make sure you set enabled = 'auto'
             'threshold' => env('APM_THRESHOLD', 200),
         ],
+
+        'httplog' => [
+            // Set to false to completely disable HTTP requests logging
+            'enabled' => env('APM_HTTPLOG', true),
+        ],
     ],
 ];

--- a/config/elastic-apm.php
+++ b/config/elastic-apm.php
@@ -42,6 +42,9 @@ return [
         //This option will bundle transaction on the route name without variables
         'use_route_uri' => env('APM_USEROUTEURI', false),
 
+        //This option will normalize transaction names
+        'normalize_uri' => env('APM_NORMALIZEURI', false),
+
     ],
 
     'spans' => [

--- a/src/Events/Span.php
+++ b/src/Events/Span.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PhilKra\ElasticApmLaravel\Events;
+
+use PhilKra\Events;
+
+/**
+ *
+ * Spans
+ *
+ * @link https://www.elastic.co/guide/en/apm/server/master/span-api.html
+ *
+ */
+class Span extends Events\Span {
+
+}

--- a/src/Events/Span.php
+++ b/src/Events/Span.php
@@ -13,4 +13,26 @@ use PhilKra\Events;
  */
 class Span extends Events\Span {
 
+	/**
+	 * @var int
+	 */
+	private $startTimestamp = false;
+
+	/**
+	 * Set the timestamp of span start (in seconds)
+	 *
+	 * @return void
+	 */
+	public function setStart(float $timestamp) {
+		$this->startTimestamp = $timestamp * 1000000; // seconds to microseconds
+	}
+
+	/**
+	 * Get the Event's Timestamp (microseconds)
+	 *
+	 * @return int
+	 */
+	public function getTimestamp() : int {
+		return $this->startTimestamp ?: parent::getTimestamp();
+	}
 }

--- a/src/Events/Span.php
+++ b/src/Events/Span.php
@@ -24,7 +24,7 @@ class Span extends Events\Span {
 	private $subtype = false;
 
 	/**
-	 * Set the timestamp of span start (in seconds)
+	 * Set the span subtype (e.g. for type "db" this can be "mysql" or "sqlite").
 	 *
 	 * @return void
 	 */

--- a/src/Events/Span.php
+++ b/src/Events/Span.php
@@ -19,6 +19,20 @@ class Span extends Events\Span {
 	private $startTimestamp = false;
 
 	/**
+	 * @var string
+	 */
+	private $subtype = false;
+
+	/**
+	 * Set the timestamp of span start (in seconds)
+	 *
+	 * @return void
+	 */
+	public function setSubtype(string $subtype) {
+		$this->subtype = $subtype;
+	}
+
+	/**
 	 * Set the timestamp of span start (in seconds)
 	 *
 	 * @return void
@@ -34,5 +48,23 @@ class Span extends Events\Span {
 	 */
 	public function getTimestamp() : int {
 		return $this->startTimestamp ?: parent::getTimestamp();
+	}
+
+	/**
+	 * Serialize Span Event
+	 *
+	 * @link https://www.elastic.co/guide/en/apm/server/master/span-api.html
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() : array {
+		$serialized = parent::jsonSerialize();
+
+		// add subtype
+		if ($this->subtype !== false) {
+			$serialized['span']['subtype'] = $this->subtype;
+		}
+
+		return $serialized;
 	}
 }

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -68,8 +68,9 @@ class RecordTransaction
         foreach (app('query-log')->toArray() as $spanContext) {
             // @see https://www.elastic.co/guide/en/apm/server/master/exported-fields-apm-span.html
             $spanDb = new Span($spanContext['name'], $transaction);
-            $spanDb->setAction('query');
+            $spanDb->setAction($spanContext['action']);
             $spanDb->setType($spanContext['type']);
+            $spanDb->setSubtype($spanContext['subtype']);
             $spanDb->setStacktrace($spanContext['stacktrace']->toArray());
             $spanDb->setContext($spanContext['context']);
 

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -31,7 +31,7 @@ class RecordTransaction
 
     /**
      * [handle description]
-     * @param  Request $request [description]
+     * @param  \Illuminate\Http\Request  $request [description]
      * @param  Closure $next [description]
      * @return [type]           [description]
      */
@@ -84,6 +84,16 @@ class RecordTransaction
         if (config('elastic-apm.transactions.use_route_uri')) {
             $transaction->setTransactionName($this->getRouteUriTransactionName($request));
         }
+
+        // handle X-Requested-By header
+				$requestedBy = $request->headers->get('X-Requested-By', 'end-user');
+
+        // X-Requested-With: XMLHttpRequest (AJAX requests)
+				if ($request->headers->get('X-Requested-With') === 'XMLHttpRequest') {
+					$requestedBy = 'end-user-ajax';
+				}
+
+				$transaction->setTags(['requested_by' => $requestedBy]);
 
         $transaction->stop($this->timer->getElapsedInMilliseconds());
 

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -65,40 +65,40 @@ class RecordTransaction
             'type' => 'HTTP'
         ]);
 
-			foreach (app('query-log')->toArray() as $spanContext) {
-					// @see https://www.elastic.co/guide/en/apm/server/master/exported-fields-apm-span.html
-					$spanDb = new Span($spanContext['name'], $transaction);
-					$spanDb->setAction('query');
-					$spanDb->setType($spanContext['type']);
-					$spanDb->setStacktrace($spanContext['stacktrace']->toArray());
-					$spanDb->setContext($spanContext['context']);
+        foreach (app('query-log')->toArray() as $spanContext) {
+            // @see https://www.elastic.co/guide/en/apm/server/master/exported-fields-apm-span.html
+            $spanDb = new Span($spanContext['name'], $transaction);
+            $spanDb->setAction('query');
+            $spanDb->setType($spanContext['type']);
+            $spanDb->setStacktrace($spanContext['stacktrace']->toArray());
+            $spanDb->setContext($spanContext['context']);
 
-					$spanDb->start();
-					$spanDb->stop($spanContext['duration']); // in [ms]
+            $spanDb->start();
+            $spanDb->stop($spanContext['duration']); // in [ms]
 
-					$spanDb->setStart($spanContext['start']); // in [us]
+            $spanDb->setStart($spanContext['start']); // in [us]
 
-					$this->agent->putEvent($spanDb);
-				}
+            $this->agent->putEvent($spanDb);
+        }
 
         if (config('elastic-apm.transactions.use_route_uri')) {
-					if (config('elastic-apm.transactions.normalize_uri')) {
-						$transaction->setTransactionName($this->getMormalizedTransactionName($request));
-					}
-					else {
-						$transaction->setTransactionName($this->getRouteUriTransactionName($request));
-					}
+            if (config('elastic-apm.transactions.normalize_uri')) {
+                $transaction->setTransactionName($this->getMormalizedTransactionName($request));
+            }
+            else {
+                $transaction->setTransactionName($this->getRouteUriTransactionName($request));
+            }
         }
 
         // handle X-Requested-By header
-				$requestedBy = $request->headers->get('X-Requested-By', 'end-user');
+        $requestedBy = $request->headers->get('X-Requested-By', 'end-user');
 
         // X-Requested-With: XMLHttpRequest (AJAX requests)
-				if ($request->headers->get('X-Requested-With') === 'XMLHttpRequest') {
-					$requestedBy = 'end-user-ajax';
-				}
+        if ($request->headers->get('X-Requested-With') === 'XMLHttpRequest') {
+            $requestedBy = 'end-user-ajax';
+        }
 
-				$transaction->setTags(['requested_by' => $requestedBy]);
+        $transaction->setTags(['requested_by' => $requestedBy]);
 
         $transaction->stop($this->timer->getElapsedInMilliseconds());
 
@@ -166,15 +166,15 @@ class RecordTransaction
         $path = $this->getRouteUriTransactionName($request);
 
         // "PUT /api/v2/product/6404" becomes "PUT /api/v2/product/N"
-				$parts = [];
+        $parts = [];
 
-				$tok = strtok($path, '/');
-				while ($tok !== false) {
-					$parts[] = is_numeric($tok) ? 'N' : $tok;
-					$tok = strtok("/");
-				}
+        $tok = strtok($path, '/');
+        while ($tok !== false) {
+            $parts[] = is_numeric($tok) ? 'N' : $tok;
+            $tok = strtok("/");
+        }
 
-				return join('/', $parts);
+        return join('/', $parts);
     }
 
     /**

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -101,7 +101,7 @@ class RecordTransaction
         $requestedBy = $request->headers->get('X-Requested-By', 'end-user');
 
         // X-Requested-With: XMLHttpRequest (AJAX requests)
-        if ($request->headers->get('X-Requested-With') === 'XMLHttpRequest') {
+        if ($request->headers->get('X-Requested-With') === 'XMLHttpRequest' && $requestedBy === 'end-user') {
             $requestedBy = 'end-user-ajax';
         }
 

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -5,6 +5,7 @@ namespace PhilKra\ElasticApmLaravel\Middleware;
 use Closure;
 use Illuminate\Support\Facades\Log;
 use PhilKra\Agent;
+use PhilKra\Events\Span;
 use PhilKra\Helper\Timer;
 
 class RecordTransaction
@@ -64,12 +65,12 @@ class RecordTransaction
             'type' => 'HTTP'
         ]);
 
-        // @see https://github.com/philkra/elastic-apm-php-agent/blob/master/docs/examples/spans.md
-				foreach (app('query-log')->toArray() as $spanContext) {
-					$spanDb = $this->agent->factory()->newSpan($spanContext['name'], $transaction);
+			foreach (app('query-log')->toArray() as $spanContext) {
+					// @see https://github.com/philkra/elastic-apm-php-agent/blob/master/docs/examples/spans.md
+					$spanDb = new Span($spanContext['name'], $transaction);
 					$spanDb->setAction('query');
 					$spanDb->setType($spanContext['type']);
-					// $spanDb->setStacktrace($spanContext['stacktrace']);
+					$spanDb->setStacktrace($spanContext['stacktrace']->toArray());
 					$spanDb->setContext($spanContext['context']);
 					$spanDb->start(); // TODO: allow to set the timer in the past
 					$spanDb->stop($spanContext['duration']); // in [ms]

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -5,7 +5,7 @@ namespace PhilKra\ElasticApmLaravel\Middleware;
 use Closure;
 use Illuminate\Support\Facades\Log;
 use PhilKra\Agent;
-use PhilKra\Events\Span;
+use PhilKra\ElasticApmLaravel\Events\Span;
 use PhilKra\Helper\Timer;
 
 class RecordTransaction

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -90,7 +90,7 @@ class RecordTransaction
 
         if (config('elastic-apm.transactions.use_route_uri')) {
             if (config('elastic-apm.transactions.normalize_uri')) {
-                $transaction->setTransactionName($this->getMormalizedTransactionName($request));
+                $transaction->setTransactionName($this->getNormalizedTransactionName($request));
             }
             else {
                 $transaction->setTransactionName($this->getRouteUriTransactionName($request));
@@ -168,7 +168,7 @@ class RecordTransaction
      *
      * @return string
      */
-    protected function getMormalizedTransactionName(\Illuminate\Http\Request $request): string
+    protected function getNormalizedTransactionName(\Illuminate\Http\Request $request): string
     {
         $path = $this->getRouteUriTransactionName($request);
 

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -65,14 +65,20 @@ class RecordTransaction
             'type' => 'HTTP'
         ]);
 
-        foreach (app('query-log')->toArray() as $spanContext) {
+        foreach (app('apm-spans-log')->toArray() as $spanContext) {
             // @see https://www.elastic.co/guide/en/apm/server/master/exported-fields-apm-span.html
             $spanDb = new Span($spanContext['name'], $transaction);
-            $spanDb->setAction($spanContext['action']);
             $spanDb->setType($spanContext['type']);
             $spanDb->setSubtype($spanContext['subtype']);
-            $spanDb->setStacktrace($spanContext['stacktrace']->toArray());
             $spanDb->setContext($spanContext['context']);
+
+            // optiponal fields
+            if (isset($spanContext['action'])) {
+                $spanDb->setAction($spanContext['action']);
+            }
+            if (isset($spanContext['stacktrace'])) {
+                $spanDb->setStacktrace($spanContext['stacktrace']->toArray());
+            }
 
             $spanDb->start();
             $spanDb->stop($spanContext['duration']); // in [ms]

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -66,14 +66,17 @@ class RecordTransaction
         ]);
 
 			foreach (app('query-log')->toArray() as $spanContext) {
-					// @see https://github.com/philkra/elastic-apm-php-agent/blob/master/docs/examples/spans.md
+					// @see https://www.elastic.co/guide/en/apm/server/master/exported-fields-apm-span.html
 					$spanDb = new Span($spanContext['name'], $transaction);
 					$spanDb->setAction('query');
 					$spanDb->setType($spanContext['type']);
 					$spanDb->setStacktrace($spanContext['stacktrace']->toArray());
 					$spanDb->setContext($spanContext['context']);
-					$spanDb->start(); // TODO: allow to set the timer in the past
+
+					$spanDb->start();
 					$spanDb->stop($spanContext['duration']); // in [ms]
+
+					$spanDb->setStart($spanContext['start']); // in [us]
 
 					$this->agent->putEvent($spanDb);
 				}

--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -231,7 +231,7 @@ class ElasticApmServiceProvider extends ServiceProvider
 						return;
 					}
 
-					$requestTime = (microtime(true) - self::$lastHttpRequestStart) * 1000; // in mileseconds
+					$requestTime = (microtime(true) - self::$lastHttpRequestStart) * 1000; // in miliseconds
 
 					$method = $request->getMethod();
 					$host = $request->getUri()->getHost();

--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -186,9 +186,10 @@ class ElasticApmServiceProvider extends ServiceProvider
             // SQL type, e.g. SELECT, INSERT, DELETE, UPDATE, SET, ...
             $queryType = strtoupper(strtok(trim($query->sql), ' '));
 
-            // https://www.elastic.co/guide/en/apm/server/master/exported-fields-apm-span.html
+            // @see https://www.elastic.co/guide/en/apm/server/master/span-api.html
             $query = [
                 'name' => $queryType,
+                'action' => 'query',
                 'type' => 'db',
                 'subtype' => 'mysql',
 

--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -182,11 +182,14 @@ class ElasticApmServiceProvider extends ServiceProvider
                 ];
             })->values();
 
+            // https://www.elastic.co/guide/en/apm/server/master/exported-fields-apm-span.html
             $query = [
                 'name' => 'Eloquent Query',
                 'type' => 'db.mysql.query',
-                'start' => round((microtime(true) - $query->time / 1000 - $this->startTime) * 1000, 3),
+
                 // calculate start time from duration
+                // $query->time is in milliseconds
+                'start' => round(microtime(true) - $query->time / 1000, 3),
                 'duration' => round($query->time, 3),
                 'stacktrace' => $stackTrace,
                 'context' => [

--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -189,7 +189,8 @@ class ElasticApmServiceProvider extends ServiceProvider
             // https://www.elastic.co/guide/en/apm/server/master/exported-fields-apm-span.html
             $query = [
                 'name' => $queryType,
-                'type' => 'db.mysql.query',
+                'type' => 'db',
+                'subtype' => 'mysql',
 
                 // calculate start time from duration
                 // $query->time is in milliseconds

--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -182,9 +182,13 @@ class ElasticApmServiceProvider extends ServiceProvider
                 ];
             })->values();
 
+
+            // SQL type, e.g. SELECT, INSERT, DELETE, UPDATE, SET, ...
+            $queryType = strtoupper(strtok(trim($query->sql), ' '));
+
             // https://www.elastic.co/guide/en/apm/server/master/exported-fields-apm-span.html
             $query = [
-                'name' => 'Eloquent Query',
+                'name' => $queryType,
                 'type' => 'db.mysql.query',
 
                 // calculate start time from duration


### PR DESCRIPTION
This pull request upgrades the `elastic-apm-laravel` plugin to make it compatible with APM 7.x stack while keeping its support for Laravel 5.7 framework.

Changes when compared with fork base:

* database query spans are labeled with query type (e.g. `SELECT`, `UPDATE`, ...)
* `X-Requested-By` HTTP request header can be used by your services to mark requests made internally: `labels.requested_by` is set (it defaults to `end_user` if no header is provided)
* additionally, `X-Requested-With: XMLHttpRequest` is checked and `labels.requested_by` is set to `end-user-ajax`
* introduce `APM_NORMALIZEURI`. If enabled, removes variable parts from URI when generating transaction name (e.g. `GET /foo/bar/123` is reported as `GET /foo/bar/N`)
* database query spans are now reported with `subtype` field (e.g. `mysql`)
* report HTTP requests spans (using GuzzleHttp's middleware)