### PR TITLE
PLAT-1434 | improve failed HTTP requests handling

### DIFF
--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace PhilKra\ElasticApmLaravel\Providers;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
@@ -15,7 +16,6 @@ use PhilKra\Helper\Timer;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\HandlerStack;
 use Psr\Http\Message\RequestInterface;
-use GuzzleHttp\Promise\FulfilledPromise;
 
 class ElasticApmServiceProvider extends ServiceProvider
 {
@@ -225,7 +225,7 @@ class ElasticApmServiceProvider extends ServiceProvider
 				function(RequestInterface $request, array $options) {
 					self::$lastHttpRequestStart = microtime(true);
 				},
-				function (RequestInterface $request, array $options, FulfilledPromise $response) {
+				function (RequestInterface $request, array $options, PromiseInterface $response) {
 					// leave early if monitoring is disabled
 					if (config('elastic-apm.active') !== true || config('elastic-apm.spans.httplog.enabled') !== true) {
 						return;

--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -225,11 +225,14 @@ class ElasticApmServiceProvider extends ServiceProvider
 				function(RequestInterface $request, array $options) {
 					self::$lastHttpRequestStart = microtime(true);
 				},
-				function (RequestInterface $request, array $options, PromiseInterface $response) {
+				function (RequestInterface $request, array $options, PromiseInterface $promise) {
 					// leave early if monitoring is disabled
 					if (config('elastic-apm.active') !== true || config('elastic-apm.spans.httplog.enabled') !== true) {
 						return;
 					}
+
+					/* @var $response \GuzzleHttp\Psr7\Response */
+					$response = $promise->wait(true);
 
 					$requestTime = (microtime(true) - self::$lastHttpRequestStart) * 1000; // in miliseconds
 
@@ -250,6 +253,7 @@ class ElasticApmServiceProvider extends ServiceProvider
 								// https://www.elastic.co/guide/en/apm/server/current/span-api.html
 								"method" => $request->getMethod(),
 								"url" => $request->getUri()->__toString(),
+								'status_code' => $response->getStatusCode(),
 							]
 						]
 					];


### PR DESCRIPTION
And report `status_code`.

Prevent the following error for failing HTTP requests:

```
[2020-01-03 11:16:27] dev.ERROR: Argument 3 passed to PhilKra\ElasticApmLaravel\Providers\ElasticApmServiceProvider::PhilKra\ElasticApmLaravel\Providers\{closure}() must be an instance of GuzzleHttp\Promise\FulfilledPromise, instance of GuzzleHttp\Promise\RejectedPromise given, called in /code/bethink/wnl-platform/vendor/guzzlehttp/guzzle/src/Middleware.php on line 135
```

![APM](https://user-images.githubusercontent.com/1929317/71726399-4097f180-2e37-11ea-85e2-908ef0224388.png)
