### PR TITLE
RecordTransaction: improve exceptions logging

### DIFF
--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -126,7 +126,7 @@ class RecordTransaction
             $this->agent->send();
         }
         catch(\Throwable $t) {
-            Log::error($t);
+            Log::error(__METHOD__ . ' - ' . get_class($t));
         }
     }
 


### PR DESCRIPTION
Log only the exception name (e.g. GuzzleHttp\Exception\ConnectException) instead of its dump.