### PR TITLE
IT-2038 | introduce APM transactions sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The following environment variables are supported in the default configuration:
 |APM_BACKTRACEDEPTH | Defaults to `25`. Depth of backtrace in query span. |
 |APM_RENDERSOURCE   | Defaults to `true`. Include source code in query span. |
 |APM_HTTPLOG        | Defaults to `true`. Will record HTTP requests performed via GuzzleHttp. |
+|APM_SAMPLING       | Defaults to `100`. Sets the percentage of transactions that will be reported to APM (ranges from 0 to 100).
 
 You may also publish the `elastic-apm.php` configuration file to change additional settings:
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ composer require bethinkpl/elastic-apm-laravel
 ## Additional features
 
 * `X-Requested-By` HTTP request header value is set as `labels.requested_by` APM transaction field (`end-user-ajax` value is used when `X-Requested-With: XMLHttpRequest` is set)
+* sampling of transactions reported to APM
 * tracking of HTTP requests performed using GuzzleHttp library. Simply add the following middleware to your Guzzle client:
 
 ```php

--- a/config/elastic-apm.php
+++ b/config/elastic-apm.php
@@ -4,6 +4,9 @@ return [
     // Sets whether the apm reporting should be active or not
     'active'        => env('APM_ACTIVE', true),
 
+    // Applies sampling of transactions to be reported to APM, defaults to 100%
+    'sampling'      => env('APM_SAMPLING', 100),
+
     'app' => [
         // The app name that will identify your app in Kibana / Elastic APM
         'appName'       => env('APM_APPNAME', 'Laravel'),

--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -62,6 +62,10 @@ class ElasticApmServiceProvider extends ServiceProvider
             'elastic-apm'
         );
 
+        // apply transactions reporting sampling
+        $samplingRate = intval(config('elastic-apm.sampling')) ?: 100;
+        self::$isSampled = $samplingRate > mt_rand(0, 100);
+
         $this->app->singleton(Agent::class, function ($app) {
             return new Agent(
                 array_merge(
@@ -70,7 +74,7 @@ class ElasticApmServiceProvider extends ServiceProvider
                         'frameworkVersion' => app()->version(),
                     ],
                     [
-                        'active' => config('elastic-apm.active'),
+                        'active' => config('elastic-apm.active') && self::$isSampled,
                         'httpClient' => config('elastic-apm.httpClient'),
                     ],
                     $this->getAppConfig(),
@@ -91,10 +95,6 @@ class ElasticApmServiceProvider extends ServiceProvider
 
         $this->app->alias(Agent::class, 'elastic-apm');
         $this->app->instance('apm-spans-log', $collection);
-
-        // apply transactions reporting sampling
-        $samplingRate = intval(config('elastic-apm.sampling')) ?: 100;
-        self::$isSampled = $samplingRate > mt_rand(0, 100);
     }
 
     /**

--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -44,7 +44,7 @@ class ElasticApmServiceProvider extends ServiceProvider
             ], 'config');
         }
 
-        if (config('elastic-apm.active') === true && config('elastic-apm.spans.querylog.enabled') !== false) {
+        if (config('elastic-apm.active') === true && config('elastic-apm.spans.querylog.enabled') !== false && self::$isSampled) {
             $this->listenForQueries();
         }
     }
@@ -233,8 +233,8 @@ class ElasticApmServiceProvider extends ServiceProvider
 					self::$lastHttpRequestStart = microtime(true);
 				},
 				function (RequestInterface $request, array $options, PromiseInterface $promise) {
-					// leave early if monitoring is disabled
-					if (config('elastic-apm.active') !== true || config('elastic-apm.spans.httplog.enabled') !== true) {
+					// leave early if monitoring is disabled or when this transaction is not sampled
+					if (config('elastic-apm.active') !== true || config('elastic-apm.spans.httplog.enabled') !== true || !self::$isSampled) {
 						return;
 					}
 

--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -28,6 +28,9 @@ class ElasticApmServiceProvider extends ServiceProvider
     /** @var float */
     private static $lastHttpRequestStart;
 
+    /** @var bool */
+    private static $isSampled = true;
+
     /**
      * Bootstrap the application services.
      *
@@ -89,6 +92,9 @@ class ElasticApmServiceProvider extends ServiceProvider
         $this->app->alias(Agent::class, 'elastic-apm');
         $this->app->instance('apm-spans-log', $collection);
 
+        // apply transactions reporting sampling
+        $samplingRate = intval(config('elastic-apm.sampling')) ?: 100;
+        self::$isSampled = $samplingRate > mt_rand(0, 100);
     }
 
     /**


### PR DESCRIPTION
Use `APM_SAMPLING` env variable to customise the sampling ratio (default to 100%).

```python
APM_SAMPLING=50
```